### PR TITLE
[PR] apply the background-color also on tab-view

### DIFF
--- a/src/main/components/buttons/button/UIButton.tsx
+++ b/src/main/components/buttons/button/UIButton.tsx
@@ -35,7 +35,6 @@ import IBaseComponent from "../../../util/types/IBaseComponent";
 import { IComponentConstants } from "../../BaseComponent";
 import { IEditorCheckBox, handleCheckboxOnChange } from "../../editors/checkbox/UIEditorCheckbox";
 import CELLEDITOR_CLASSNAMES from "../../editors/CELLEDITOR_CLASSNAMES";
-import _ from "underscore";
 
 // If the Buttons text contains HTML, render it in a span, because the button on its own isn't able to render HTML.
 export const RenderButtonHTML: FC<{ text:string }> = (props) => {
@@ -106,7 +105,7 @@ const UIButton: FC<IButton & IExtendableButton | IEditorCheckBox & IComponentCon
     }, [onLoadCallback, id, props.preferredSize, props.maximumSize, props.minimumSize, props.text, props.designerUpdate, props.forwardedRef.current]);
 
     /** When the button is clicked, a pressButtonRequest is sent to the server with the buttons name as componentId */
-    const onButtonPress = useMemo(() => _.debounce((event: any) => {
+    const onButtonPress = (event:any) => {
         if (!isCheckboxCellEditor(props)) {
             // ReactUI as lib, execute given event
             if (props.onClick) {
@@ -136,7 +135,7 @@ const UIButton: FC<IButton & IExtendableButton | IEditorCheckBox & IComponentCon
             )
         }
 
-    },800, true), [props]);
+    }
 
     /** Returns the correct Button element to render, hyperlink, "normal" button, uploadbutton */
     const getElementToRender = () => {

--- a/src/main/components/buttons/button/UIButton.tsx
+++ b/src/main/components/buttons/button/UIButton.tsx
@@ -35,6 +35,7 @@ import IBaseComponent from "../../../util/types/IBaseComponent";
 import { IComponentConstants } from "../../BaseComponent";
 import { IEditorCheckBox, handleCheckboxOnChange } from "../../editors/checkbox/UIEditorCheckbox";
 import CELLEDITOR_CLASSNAMES from "../../editors/CELLEDITOR_CLASSNAMES";
+import _ from "underscore";
 
 // If the Buttons text contains HTML, render it in a span, because the button on its own isn't able to render HTML.
 export const RenderButtonHTML: FC<{ text:string }> = (props) => {
@@ -105,7 +106,7 @@ const UIButton: FC<IButton & IExtendableButton | IEditorCheckBox & IComponentCon
     }, [onLoadCallback, id, props.preferredSize, props.maximumSize, props.minimumSize, props.text, props.designerUpdate, props.forwardedRef.current]);
 
     /** When the button is clicked, a pressButtonRequest is sent to the server with the buttons name as componentId */
-    const onButtonPress = (event:any) => {
+    const onButtonPress = useMemo(() => _.debounce((event: any) => {
         if (!isCheckboxCellEditor(props)) {
             // ReactUI as lib, execute given event
             if (props.onClick) {
@@ -135,7 +136,7 @@ const UIButton: FC<IButton & IExtendableButton | IEditorCheckBox & IComponentCon
             )
         }
 
-    }
+    },800, true), [props]);
 
     /** Returns the correct Button element to render, hyperlink, "normal" button, uploadbutton */
     const getElementToRender = () => {

--- a/src/main/components/panels/tabsetpanel/TabsetPanelImpl.tsx
+++ b/src/main/components/panels/tabsetpanel/TabsetPanelImpl.tsx
@@ -186,7 +186,7 @@ const TabsetPanelImpl: FC<ITabsetImpl & IComponentConstants> = (props) => {
                 style={props.screen_modal_ || props.content_modal_ ? { height: (prefSize?.height as number), width: prefSize?.width } : { ...props.layoutStyle, ...props.compStyle }}>
                 <TabView
                     ref={panelRef}
-                    //style={{"backgroundColor": props.compStyle.background} as CSSProperties}
+                    style={{"--nav-background": props.compStyle.background, "--tab-navbar-background": props.compStyle.background} as CSSProperties}
                     activeIndex={props.selectedIndex}
                     onTabChange={event => props.onTabChange(event.index)}
                     onBeforeTabClose={event => props.onTabClose(event.index)}

--- a/src/main/components/panels/tabsetpanel/TabsetPanelImpl.tsx
+++ b/src/main/components/panels/tabsetpanel/TabsetPanelImpl.tsx
@@ -186,7 +186,7 @@ const TabsetPanelImpl: FC<ITabsetImpl & IComponentConstants> = (props) => {
                 style={props.screen_modal_ || props.content_modal_ ? { height: (prefSize?.height as number), width: prefSize?.width } : { ...props.layoutStyle, ...props.compStyle }}>
                 <TabView
                     ref={panelRef}
-                    style={{"--nav-background": props.compStyle.background} as CSSProperties}
+                    style={{"--nav-background": props.compStyle.background, "--tab-navbar-background": props.compStyle.background} as CSSProperties}
                     activeIndex={props.selectedIndex}
                     onTabChange={event => props.onTabChange(event.index)}
                     onBeforeTabClose={event => props.onTabClose(event.index)}


### PR DESCRIPTION
Setting the background-color on the TabsetPanel had no effect on the tab-view part of the UITabsetPanel.

I am having something like that in Java:
```java
  public SimpleWorkScreen(IWorkScreenApplication pApplication, AbstractConnection pConnection) throws Throwable {
    super(pApplication, pConnection, null);

    setLayout(new UIBorderLayout());

    UITabsetPanel tp = new UITabsetPanel();
    tp.setBackground(UIColor.red);
    add(tp, IBorderLayout.CENTER);

    UIPanel p = new UIPanel();
    p.setBackground(UIColor.white);
    tp.add(p, "red button on red tab");

    UIButton b = new UIButton("this button is red");
    b.setBackground(UIColor.red);
    p.add(b);

    tp.add(new UIPanel(), "another, unselected tab on the red tabsetpanel");
  }
```

With the fix, the result looks more as I'd expect it to behave:
![grafik](https://github.com/user-attachments/assets/0f6159d0-4951-4c54-ac89-1803e9fda869)

Whether some sort of additional styling to make that a bit more appealing, is still open for discussion.
That's why I set this PR as "allow edits by maintainers".

Have a nice day! 🌄

